### PR TITLE
Fix race condition in FakeAsync timeout test

### DIFF
--- a/test/testing/fake_async_test.dart
+++ b/test/testing/fake_async_test.dart
@@ -346,10 +346,10 @@ main() {
             StreamSubscription subscription;
             var periodic =
                 new Stream.periodic(const Duration(minutes: 1), (i) => i);
-            subscription = periodic.listen(events.add, cancelOnError: true);
+            subscription = periodic.listen(events.add);
             async.elapse(const Duration(minutes: 3));
-            subscription.cancel();
             expect(events, [0, 1, 2]);
+            subscription.cancel();
           });
         });
 
@@ -359,16 +359,15 @@ main() {
             var errors = [];
             var controller = new StreamController();
             var timed = controller.stream.timeout(const Duration(minutes: 2));
-            var subscription = timed.listen(events.add,
-                onError: errors.add, cancelOnError: true);
+            var subscription = timed.listen(events.add, onError: errors.add);
             controller.add(0);
             async.elapse(const Duration(minutes: 1));
             expect(events, [0]);
             async.elapse(const Duration(minutes: 1));
-            subscription.cancel();
             expect(errors, hasLength(1));
             expect(errors.first, new isInstanceOf<TimeoutException>());
-            return controller.close();
+            subscription.cancel();
+            controller.close();
           });
         });
       });


### PR DESCRIPTION
Dart SDK commit 6255638cd0623b3aa41596b98f4584876f6b8822 introduced
changes to stream subscription cancellation. cancelOnError was
irrelevant to the periodic and timeout tests.