### PR TITLE
Non-periodic Timers are not active while executing callback()

### DIFF
--- a/lib/testing/src/fake_async.dart
+++ b/lib/testing/src/fake_async.dart
@@ -248,8 +248,8 @@ class _FakeAsync extends FakeAsync {
       timer._callback(timer);
       timer._nextCall += timer._duration;
     } else {
-      timer._callback();
       _timers.remove(timer);
+      timer._callback();
     }
   }
 

--- a/test/testing/fake_async_test.dart
+++ b/test/testing/fake_async_test.dart
@@ -601,5 +601,26 @@ main() {
         });
       });
     });
+
+    group('timers', () {
+      test('should behave like real timers', () {
+        return new FakeAsync().run((async) {
+          var timeout = const Duration(minutes: 1);
+          int counter = 0;
+          var timer;
+          timer = new Timer(timeout, () {
+            counter++;
+            expect(timer.isActive, isFalse,
+                reason: "is not active while executing callback");
+          });
+          expect(timer.isActive, isTrue,
+              reason: "is active before executing callback");
+          async.elapse(timeout);
+          expect(counter, equals(1), reason: "timer executed");
+          expect(timer.isActive, isFalse,
+              reason: "is not active after executing callback");
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Both the DartVM and dartpad.dartlang.org mark a timer as not-active
while the callback is executing. This can be used in production code
to test some condition - but fails when using quiver-dart/async.dart.